### PR TITLE
Add sudo chown -R vscode:vscode ${ANDROID_HOME} to android-cli

### DIFF
--- a/src/android-cli/install.sh
+++ b/src/android-cli/install.sh
@@ -35,6 +35,9 @@ cd ${PATH_COMMAND_LINE_TOOLS}
 mv !(tools) tools
 cd ${ANDROID_HOME}
 
+# https://github.com/akhildevelops/devcontainer-features/issues/7
+sudo chown -R vscode:vscode ${ANDROID_HOME}
+
 # Set Path
 export PATH=${PATH_COMMAND_LINE_TOOLS}/tools/bin:$PATH
 


### PR DESCRIPTION
This should, hopefully, fix #7.

I HAVE NOT (!) tested this specific change - I'm not sure how I could "locally" test a dev container feature?

I HAVE however tested manually running `sudo chown -R vscode:vscode /opt/android/` in a Codespace AFTER install, and it helps.

I don't know how to avoid hard-coding the `vscode:vscode` UID/GID in the `chown`... the `install.sh` script (clearly) runs as `root`; I'm not sure if Dev Containers have some ENV var which specifies "the UID/GID under which the workspace will eventually run"?

@akhildevelops would you be willing to merge this as-is? I can test it after you've merged it; great if it works, if it does not, we can revert it.

@jingtang10 FYI, this MAY fix https://github.com/google/android-fhir/issues/2614.