### PR TITLE
Revert "Add sudo chown -R vscode:vscode ${ANDROID_HOME} to android-cli"

### DIFF
--- a/src/android-cli/install.sh
+++ b/src/android-cli/install.sh
@@ -35,9 +35,6 @@ cd ${PATH_COMMAND_LINE_TOOLS}
 mv !(tools) tools
 cd ${ANDROID_HOME}
 
-# https://github.com/akhildevelops/devcontainer-features/issues/7
-sudo chown -R vscode:vscode ${ANDROID_HOME}
-
 # Set Path
 export PATH=${PATH_COMMAND_LINE_TOOLS}/tools/bin:$PATH
 


### PR DESCRIPTION
Reverts akhildevelops/devcontainer-features#8

See https://github.com/akhildevelops/devcontainer-features/issues/11 for why.

